### PR TITLE
Make CI pass with st -v

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,4 +38,5 @@ jobs:
         with:
           target: 'run'
           pkgname: '.'
-          command: 'st -v'
+          # `st -v` exits with code 1, invert it so that this workflow passes
+          command: '! st -v'


### PR DESCRIPTION
Since `st -v` exits with exit code 1, invert it so that the workflow passes.