### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.r0.3eede6e
+	pkgver = 0.9.r1.de85fe0
 	pkgrel = 1
 	url = https://github.com/RoyARG02/st
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.r0.3eede6e
+pkgver=0.9.r1.de85fe0
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit de85fe07b83e8ba339ddef545d695b5e34c43822
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Sat Nov 5 13:13:05 2022 +0530

    Merge updates from upstream

    Squashed commit of the following:

    commit e5e959835b195c023d1f685ef4dbbcfc3b5120b2
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Tue Oct 25 17:11:11 2022 +0200

        fix buffer overflow when handling long composed input

        To reproduce the issue:

        "
        If you already have the multi-key enabled on your system, then add this line
        to your ~/.XCompose file:

        [...]
        <question> <T> <E> <S> <T> <question> :
        "1234567890123456789012345678901234567890123456789012345678901234567890"
        "

        Reported by and an initial patch by Andy Gozas <andy@gozas.me>, thanks!

        Adapted the patch, for now st (like dmenu) handles a fixed amount of composed
        characters, or otherwise ignores it. This is done for simplicity sake.
