### PR TITLE
Update from upstream

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = st-royarg-git
 	pkgdesc = A modified version of the simple virtual terminal emulator for X.
-	pkgver = 0.9.r1.de85fe0
+	pkgver = 0.9.r2.4a7815a
 	pkgrel = 1
 	url = https://github.com/RoyARG02/st
 	arch = i686

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Anurag Roy <anuragr9847@gmail.com>
 _pkgname="st"
 pkgname="$_pkgname-royarg-git"
-pkgver=0.9.r1.de85fe0
+pkgver=0.9.r2.4a7815a
 pkgrel=1
 pkgdesc="A modified version of the simple virtual terminal emulator for X."
 arch=('i686' 'x86_64' 'armv7h')


### PR DESCRIPTION
commit 4a7815a6951f3a3ca8f7fbb9b5452b18efdcc86b
Author: Anurag Roy <anuragr9847@gmail.com>
Date:   Mon Feb 13 22:25:59 2023 +0530

    Merge updates from upstream
    
    Squashed commit of the following:
    
    commit 211964d56ee00a7d46e251cbc150afb79138ae37
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Tue Feb 7 20:00:59 2023 +0100
    
        ignore C1 control characters in UTF-8 mode
    
        Ignore processing and printing C1 control characters in UTF-8 mode.
        These are in the range: 0x80 - 0x9f.
    
        By default in st the mode is set to UTF-8.
    
        This matches more the behaviour of xterm with the options -u8 or +u8 also.
        Also see the xterm resource "allowC1Printable".
    
        Let me know if this breaks something, in most cases I don't think so.
    
        As usual a very good reference is:
        https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
    
    commit f17abd25b376c292f783062ecf821453eaa9cc4c
    Author: Adam Price <komidore64@gmail.com>
    Date:   Tue Feb 7 19:54:29 2023 +0100
    
        Add support for DSR response "OK" escape sequence
    
        "VT100 defines an escape sequence [1] called Device Status Report (DSR). When
        the DSR sequence received is `csi 5n`, an "OK" response `csi 0n` is returned.
        This patch adds that "OK" response.
    
        I encountered this missing sequence when I noticed that fzf [2] would clobber
        my prompt whenever completing a find.
    
        To test that ST doesn't currently respond to `csi 5n`, use fzf's shell
        extension in ST's repo to complete the path for a file.
    
            my-fancy-prompt $ vim **<tab>
            <select a file>
            st.c
    
        Select a file with <enter>, and notice that fzf clobbers some or all of your
        prompt.
    
        After applying this patch, do the same test as above and notice that fzf has no
        longer clobbered your prompt by placing the file name in the correct position
        in your command.
    
            my-fancy-prompt $ vim **<tab>
            <select a file>
            my-fancy prompt $ vim st.c
    
        Thank you for considering my first patch submission.
    
        [1] https://www.xfree86.org/current/ctlseqs.html#VT100%20Mode
        [2] https://github.com/junegunn/fzf
        "
    
        Patch slightly adapted with input from the mailinglist,
    
    commit 7e8050cc621f27002eaf1be8114dee2497beff91
    Author: Hiltjo Posthuma <hiltjo@codemadness.org>
    Date:   Sun Feb 5 13:29:35 2023 +0100
    
        Fixed OSC color reset without parameter->resets all colors
    
        Adapted from (garbled) patch by wim <wim@thinkerwim.org>
    
        Additional notes: it should reset all the colors using xloadcols().
        To reproduce: set a different (theme) color using some escape code, then reset
        it:
    
            printf '\x1b]104\x07'
